### PR TITLE
Fixing nan error

### DIFF
--- a/strec/kagan.py
+++ b/strec/kagan.py
@@ -89,5 +89,6 @@ def ang_from_R1R2(R1, R2):
     Returns:    
         float: angle between eigenvectors 
     """
-
-    return np.arccos((np.trace(np.dot(R1, R2.transpose())) - 1.) / 2.)
+    
+#    return np.arccos((np.trace(np.dot(R1, R2.transpose())) - 1.) / 2.)
+    return np.arccos(np.clip((np.trace(np.dot(R1, R2.transpose())) - 1.) / 2.,-1,1))


### PR DESCRIPTION
In some corner cases such as kagan calculation between: B1=[132, 87, 2] and B2=[132, 77, -2]
a nan value is returned.
Now, it is able to be calculated.